### PR TITLE
Allow hiding power circle

### DIFF
--- a/NestThermostat.js
+++ b/NestThermostat.js
@@ -239,7 +239,7 @@ class NestThermostat {
 			cx: this.properties.radius + this.options.iconSize/2.75,
 			cy: (this.properties.radius + ((this.properties.radius/16) * 10)) - (this.options.iconSize/2) + ((this.options.iconSize/16) * 13),
 			r: this.options.iconSize/4,
-			class: 'dial__shape dial--state--off'
+			class: 'dial__shape dial--state--off power__circle'
 		}, this.dom.svg);
 
 		// lblPowerLabel


### PR DESCRIPTION
Added one class to the ```lblPowerCircle``` to allow custom css to hide it if unused (or for any other reason).  See #6 