### PR TITLE
Replace console.log with Log.log

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -1,3 +1,4 @@
+const Log = require('logger')
 const bodyParser = require('body-parser');
 const NodeHelper = require('node_helper');
 
@@ -7,8 +8,8 @@ module.exports = NodeHelper.create({
 		this.expressApp.post('/remote-nest-thermostat', (req, res) => {
 			const params = req.body;
 
-			console.log(`MMM-NestRemoteThermostat Node helper: New message receive: `);
-			console.log(JSON.stringify(params, null, 4))
+			Log.log(`MMM-NestRemoteThermostat Node helper: New message received: `);
+			Log.log(JSON.stringify(params, null, 4))
 
 			const payload = {
 				thermostatId: params.thermostatId,
@@ -28,7 +29,7 @@ module.exports = NodeHelper.create({
 
 	socketNotificationReceived(notificationName, payload) {
 		if (notificationName === 'MMM-NestRemoteThermostat.INIT') {
-			console.log(`MMM-NestRemoteThermostat Node helper: Init notification received from module for thermostat "${payload.thermostatId}".`); // eslint-disable-line no-console
+			Log.log(`MMM-NestRemoteThermostat Node helper: Init notification received from module for thermostat "${payload.thermostatId}".`); // eslint-disable-line no-console
 		}
 	},
 });

--- a/node_helper.js
+++ b/node_helper.js
@@ -8,8 +8,8 @@ module.exports = NodeHelper.create({
 		this.expressApp.post('/remote-nest-thermostat', (req, res) => {
 			const params = req.body;
 
-			Log.log(`MMM-NestRemoteThermostat Node helper: New message received: `);
-			Log.log(JSON.stringify(params, null, 4))
+			Log.debug(`MMM-NestRemoteThermostat Node helper: New message received: `);
+			Log.debug(JSON.stringify(params, null, 4))
 
 			const payload = {
 				thermostatId: params.thermostatId,


### PR DESCRIPTION
Updating the logging method to the MagicMirror built-in logger allows users to set the log level using the global config option.
(I'd also suggest changing the log level to `debug` instead of `log`--at least for lines 10-11--but I didn't want to do that without running it by you first).
@sisimomo 